### PR TITLE
Kernel length updates

### DIFF
--- a/scripts/deploy_glm_fits.sh
+++ b/scripts/deploy_glm_fits.sh
@@ -2,4 +2,4 @@
 # Make sure you run conda activate <env> first
 # to run this from an environment where the allenSDK is installed
 
-python deploy_glm_fits.py --version 102_active_mongo --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 
+python deploy_glm_fits.py --version 104_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 

--- a/scripts/deploy_glm_fits.sh
+++ b/scripts/deploy_glm_fits.sh
@@ -2,4 +2,4 @@
 # Make sure you run conda activate <env> first
 # to run this from an environment where the allenSDK is installed
 
-python deploy_glm_fits.py --version 106_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 
+python deploy_glm_fits.py --version 109_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 

--- a/scripts/deploy_glm_fits.sh
+++ b/scripts/deploy_glm_fits.sh
@@ -2,4 +2,4 @@
 # Make sure you run conda activate <env> first
 # to run this from an environment where the allenSDK is installed
 
-python deploy_glm_fits.py --version 105_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 
+python deploy_glm_fits.py --version 106_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 

--- a/scripts/deploy_glm_fits.sh
+++ b/scripts/deploy_glm_fits.sh
@@ -2,4 +2,4 @@
 # Make sure you run conda activate <env> first
 # to run this from an environment where the allenSDK is installed
 
-python deploy_glm_fits.py --version 104_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 
+python deploy_glm_fits.py --version 105_active --env-path /home/alex.piet/codebase/miniconda3/envs/np --src-path /home/alex.piet/codebase/NP/visual_behavior_glm_NP/ --job-end-fraction 1 

--- a/visual_behavior_glm_NP/GLM_analysis_tools.py
+++ b/visual_behavior_glm_NP/GLM_analysis_tools.py
@@ -912,6 +912,37 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         x['image6_weights'],
         x['image7_weights']
         ],axis=0),axis=1)
+    if 'hits_image0_weights' in weights_df:
+        weights_df['all_hits_weights'] = weights_df.apply(lambda x: np.mean([
+            x['hits_image0_weights'],
+            x['hits_image1_weights'],
+            x['hits_image2_weights'],
+            x['hits_image3_weights'],       
+            x['hits_image4_weights'],
+            x['hits_image5_weights'],
+            x['hits_image6_weights'],
+            x['hits_image7_weights']
+            ],axis=0),axis=1)       
+        weights_df['all_misses_weights'] = weights_df.apply(lambda x: np.mean([
+            x['misses_image0_weights'],
+            x['misses_image1_weights'],
+            x['misses_image2_weights'],
+            x['misses_image3_weights'],       
+            x['misses_image4_weights'],
+            x['misses_image5_weights'],
+            x['misses_image6_weights'],
+            x['misses_image7_weights']
+            ],axis=0),axis=1)      
+        weights_df['all_passive_change_weights'] = weights_df.apply(lambda x: np.mean([
+            x['passive_change_image0_weights'],
+            x['passive_change_image1_weights'],
+            x['passive_change_image2_weights'],
+            x['passive_change_image3_weights'],       
+            x['passive_change_image4_weights'],
+            x['passive_change_image5_weights'],
+            x['passive_change_image6_weights'],
+            x['passive_change_image7_weights']
+            ],axis=0),axis=1)       
 
     # Compute preferred image kernel
     weights_df['preferred_image_weights'] = weights_df.apply(lambda x: compute_preferred_kernel([

--- a/visual_behavior_glm_NP/GLM_analysis_tools.py
+++ b/visual_behavior_glm_NP/GLM_analysis_tools.py
@@ -926,7 +926,7 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         ]),axis=1) 
 
     # compute share_image kernel
-    weights_df['shared_image_weights'] = weights_df.apply(lambda x: compute_shared_image_kernel(
+    weights_df['shared_images_weights'] = weights_df.apply(lambda x: compute_shared_image_kernel(
         x['image_set'],
         [x['image0_weights'],
         x['image1_weights'],
@@ -937,7 +937,7 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         x['image6_weights'],
         x['image7_weights']
         ]),axis=1)
-    weights_df['non_shared_image_weights'] = weights_df.apply(lambda x: \
+    weights_df['non_shared_images_weights'] = weights_df.apply(lambda x: \
         compute_non_shared_image_kernel(
         x['image_set'],
         [x['image0_weights'],

--- a/visual_behavior_glm_NP/GLM_analysis_tools.py
+++ b/visual_behavior_glm_NP/GLM_analysis_tools.py
@@ -902,6 +902,7 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
 
     print('Computing average kernels') 
     # Compute generic image kernel
+    print('all image kernel')
     weights_df['all-images_weights'] = weights_df.apply(lambda x: np.mean([
         x['image0_weights'],
         x['image1_weights'],
@@ -912,39 +913,9 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         x['image6_weights'],
         x['image7_weights']
         ],axis=0),axis=1)
-    if 'hits_image0_weights' in weights_df:
-        weights_df['all_hits_weights'] = weights_df.apply(lambda x: np.mean([
-            x['hits_image0_weights'],
-            x['hits_image1_weights'],
-            x['hits_image2_weights'],
-            x['hits_image3_weights'],       
-            x['hits_image4_weights'],
-            x['hits_image5_weights'],
-            x['hits_image6_weights'],
-            x['hits_image7_weights']
-            ],axis=0),axis=1)       
-        weights_df['all_misses_weights'] = weights_df.apply(lambda x: np.mean([
-            x['misses_image0_weights'],
-            x['misses_image1_weights'],
-            x['misses_image2_weights'],
-            x['misses_image3_weights'],       
-            x['misses_image4_weights'],
-            x['misses_image5_weights'],
-            x['misses_image6_weights'],
-            x['misses_image7_weights']
-            ],axis=0),axis=1)      
-        weights_df['all_passive_change_weights'] = weights_df.apply(lambda x: np.mean([
-            x['passive_change_image0_weights'],
-            x['passive_change_image1_weights'],
-            x['passive_change_image2_weights'],
-            x['passive_change_image3_weights'],       
-            x['passive_change_image4_weights'],
-            x['passive_change_image5_weights'],
-            x['passive_change_image6_weights'],
-            x['passive_change_image7_weights']
-            ],axis=0),axis=1)       
 
     # Compute preferred image kernel
+    print('preferred image kernel')
     weights_df['preferred_image_weights'] = weights_df.apply(lambda x: compute_preferred_kernel([
         x['image0_weights'],
         x['image1_weights'],
@@ -957,6 +928,7 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         ]),axis=1) 
 
     # compute share_image kernel
+    print('shared image kernel')
     weights_df['shared_images_weights'] = weights_df.apply(lambda x: compute_shared_image_kernel(
         x['image_set'],
         [x['image0_weights'],
@@ -968,6 +940,7 @@ def build_weights_df(run_params,results_pivoted, cache_results=False,load_cache=
         x['image6_weights'],
         x['image7_weights']
         ]),axis=1)
+    print('non share image kernel')
     weights_df['non_shared_images_weights'] = weights_df.apply(lambda x: \
         compute_non_shared_image_kernel(
         x['image_set'],

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -135,6 +135,7 @@ def get_analysis_dfs(version,save=True):
     weights_df = gat.get_weights_df(version, results_pivoted)
     
     if save:
+        print('Saving to pickle files, next time use gfd.load_analysis_dfs')
         OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
         r_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version), 'results.pkl')
         rp_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version), 'results_pivoted.pkl')

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -96,7 +96,7 @@ def figure_dump(version, run_params, results, results_pivoted, weights_df):
     stats = gvt.var_explained_by_experience(results_pivoted, run_params,savefig=True)
     stats = gvt.plot_dropout_summary_population(results, run_params,savefig=True)
     dropouts = ['all-images','omissions','behavioral','pupil','running','licks',
-        'task','hits','misses','shared_image','non_shared_image']
+        'task','hits','misses','shared_images','non_shared_images']
     for d in dropouts:
         stats = gvt.plot_dropout_summary_by_area(results, run_params,d,savefig=True)
     closeall()
@@ -114,6 +114,10 @@ def figure_dump(version, run_params, results, results_pivoted, weights_df):
             closeall()
 
     for k in kernels:
+        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 
+            save_results=True)
+        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
+            save_results=True)
         for a in areas:
             try:
                 gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -50,9 +51,7 @@ if False:
 
     # Merge active/passive
     #df_combined = gat.merge_active_passive(df_active, df_passive)
-    results_c = gat.merge_active_passive(results_a, results_p)
-    results_pivoted_c = gat.merge_active_passive(results_pivoted_a, results_pivoted_p)
-    weights_df_c = gat.merge_active_passive(weights_df_a, weights_df_p)
+    run_params, results_c, results_pivoted_c, weights_df_c = gfd.get_analysis_dfs(root_version)
     stats = gvt.var_explained_by_experience(results_pivoted_c, run_params,merged=True) 
     stats = gvt.plot_dropout_summary_population(results_c, run_params,merged=True) 
     stats = gvt.plot_dropout_summary_by_area(results_c, run_params, 'all-images',merged=True)
@@ -85,6 +84,50 @@ if False:
     gvt.plot_kernel_comparison(weights_df, run_params, 'non_shared_image')
     gvt.plot_kernel_comparison_shared_images(weights_df,run_params)
 
+
+def get_active_passive_dfs(root_version,save=True):
+    version_a = root_version+'_active'
+    version_p = root_version+'_passive'
+
+    run_params_a, results_a,results_pivoted_a, weights_df_a = load_analysis_dfs(version_a)
+    run_params_p, results_p,results_pivoted_p, weights_df_p = load_analysis_dfs(version_p)
+
+    results_c = gat.merge_active_passive(results_a, results_p)
+    results_pivoted_c = gat.merge_active_passive(results_pivoted_a, results_pivoted_p)
+    weights_df_c = gat.merge_active_passive(weights_df_a, weights_df_p)
+    if save:
+        OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
+        r_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version_a), 'combined_results.pkl')
+        rp_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version_a), 'combined_results_pivoted.pkl')
+        weights_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version_a), 'combined_weights_df.pkl')
+        results.to_pickle(r_filename)
+        results_pivoted.to_pickle(rp_filename)
+        weights_df.to_pickle(weights_filename)
+    
+    return results_c, results_pivoted_c, weights_df_c
+
+
+def load_active_passive_dfs(root_version): 
+    VERSION = root_version+'_active'
+    OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
+    r_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'combined_results.pkl')
+    rp_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'combined_results_pivoted.pkl')
+    weights_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'combined_weights_df.pkl')
+
+    print('loading run_params')
+    run_params = glm_params.load_run_json(VERSION) 
+
+    print('loading results df')
+    results = pd.read_pickle(r_filename)
+
+    print('loading results_pivoted df')
+    results_pivoted = pd.read_pickle(rp_filename)
+
+    print('loading weights_df')
+    weights_df = pd.read_pickle(weights_filename)
+    return run_params, results, results_pivoted, weights_df
+
+
 def get_analysis_dfs(version,save=True):
     run_params = glm_params.load_run_json(version)
     results = gat.get_summary_results(version)
@@ -100,6 +143,8 @@ def get_analysis_dfs(version,save=True):
         results_pivoted.to_pickle(rp_filename)
         weights_df.to_pickle(weights_filename)
     return run_params, results, results_pivoted, weights_df
+
+
 
 def load_analysis_dfs(VERSION):
     OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -92,42 +92,46 @@ def get_analysis_dfs(version):
     weights_df = gat.get_weights_df(version, results_pivoted)
     return run_params, results, results_pivoted, weights_df
 
-def figure_dump(version, run_params, results, results_pivoted, weights_df):
+def figure_dump(version, run_params, results, results_pivoted, weights_df,plot_areas=True):
     stats = gvt.var_explained_by_experience(results_pivoted, run_params,savefig=True)
     stats = gvt.plot_dropout_summary_population(results, run_params,savefig=True)
     dropouts = ['all-images','omissions','behavioral','pupil','running','licks',
         'task','hits','misses','shared_images','non_shared_images']
     for d in dropouts:
         stats = gvt.plot_dropout_summary_by_area(results, run_params,d,savefig=True)
-    closeall()
+        closeall()
 
     kernels = ['omissions','all-images','hits','misses','licks','running','pupil',
         'shared_images','non_shared_images']
     areas = weights_df['structure_acronym'].unique()
     for k in kernels:
-        gvt.plot_kernel_comparison(weights_df, run_params, k)
-        for a in areas:
-            try:
-                gvt.plot_kernel_comparison(weights_df, run_params, k,area_filter=[a])
-            except:
-                pass
-            closeall()
+        if k in run_params['kernels']:
+            gvt.plot_kernel_comparison(weights_df, run_params, k)
+            if plot_areas:
+                for a in areas:
+                    try:
+                        gvt.plot_kernel_comparison(weights_df, run_params, k,area_filter=[a])
+                    except:
+                        pass
+                    closeall()
+        closeall()
 
     for k in kernels:
-        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 
-            save_results=True)
-        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
-            save_results=True)
-        for a in areas:
-            try:
-                gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 
-                    area_filter=[a],save_results=True)
-                gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
-                    area_filter=[a],save_results=True)
-            except:
-                pass
-            closeall()
-
-
+        if k in run_params['kernels']:
+            gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 
+                save_results=True)
+            gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
+                save_results=True)
+            if plot_areas:
+                for a in areas:
+                    try:
+                        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Familiar'], 
+                            area_filter=[a],save_results=True)
+                        gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
+                            area_filter=[a],save_results=True)
+                    except:
+                        pass
+                    closeall()
+        closeall()
 
  

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -85,12 +85,42 @@ if False:
     gvt.plot_kernel_comparison(weights_df, run_params, 'non_shared_image')
     gvt.plot_kernel_comparison_shared_images(weights_df,run_params)
 
-def get_analysis_dfs(version):
+def get_analysis_dfs(version,save=True):
     run_params = glm_params.load_run_json(version)
     results = gat.get_summary_results(version)
     results_pivoted = gat.get_pivoted_results(results)
     weights_df = gat.get_weights_df(version, results_pivoted)
+    
+    if save:
+        OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
+        r_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version), 'results.pkl')
+        rp_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version), 'results_pivoted.pkl')
+        weights_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(version), 'weights_df.pkl')
+        results.to_pickle(r_filename)
+        results_pivoted.to_pickle(rp_filename)
+        weights_df.to_pickle(weights_filename)
     return run_params, results, results_pivoted, weights_df
+
+def load_analysis_dfs(VERSION):
+    OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
+    r_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'results.pkl')
+    rp_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'results_pivoted.pkl')
+    weights_filename = os.path.join(OUTPUT_DIR_BASE, 'v_'+str(VERSION), 'weights_df.pkl')
+
+    print('loading run_params')
+    run_params = glm_params.load_run_json(VERSION) 
+
+    print('loading results df')
+    results = pd.read_pickle(r_filename)
+
+    print('loading results_pivoted df')
+    results_pivoted = pd.read_pickle(rp_filename)
+
+    print('loading weights_df')
+    weights_df = pd.read_pickle(weights_filename)
+    return run_params, results, results_pivoted, weights_df
+
+
 
 def figure_dump(version, run_params, results, results_pivoted, weights_df,plot_areas=True):
     stats = gvt.var_explained_by_experience(results_pivoted, run_params,savefig=True)
@@ -122,6 +152,7 @@ def figure_dump(version, run_params, results, results_pivoted, weights_df,plot_a
                 save_results=True)
             gvt.kernel_evaluation(weights_df, run_params, k,session_filter=['Novel'], 
                 save_results=True)
+            gvt.kernel_evaluation(weights_df, run_params, k,save_results=True)
             if plot_areas:
                 for a in areas:
                     try:

--- a/visual_behavior_glm_NP/GLM_fit_dev.py
+++ b/visual_behavior_glm_NP/GLM_fit_dev.py
@@ -96,13 +96,13 @@ def figure_dump(version, run_params, results, results_pivoted, weights_df):
     stats = gvt.var_explained_by_experience(results_pivoted, run_params,savefig=True)
     stats = gvt.plot_dropout_summary_population(results, run_params,savefig=True)
     dropouts = ['all-images','omissions','behavioral','pupil','running','licks',
-        'task','hits','misses']
+        'task','hits','misses','shared_image','non_shared_image']
     for d in dropouts:
         stats = gvt.plot_dropout_summary_by_area(results, run_params,d,savefig=True)
     closeall()
 
     kernels = ['omissions','all-images','hits','misses','licks','running','pupil',
-        'shared_image','non_shared_image']
+        'shared_images','non_shared_images']
     areas = weights_df['structure_acronym'].unique()
     for k in kernels:
         gvt.plot_kernel_comparison(weights_df, run_params, k)

--- a/visual_behavior_glm_NP/GLM_fit_tools.py
+++ b/visual_behavior_glm_NP/GLM_fit_tools.py
@@ -52,6 +52,11 @@ def load_fit_experiment(ecephys_session_id, run_params):
         kernels_to_limit_per_image_cycle.append('hits')
         kernels_to_limit_per_image_cycle.append('misses')
         kernels_to_limit_per_image_cycle.append('passive_change')
+    if 'hits_image0' in run_params['kernels']:
+        for i in range(0,8):
+            kernels_to_limit_per_image_cycle.append('hits_image{}'.format(i))
+            kernels_to_limit_per_image_cycle.append('misses_image{}'.format(i))
+            kernels_to_limit_per_image_cycle.append('passive_change_image{}'.format(i))
     for k in kernels_to_limit_per_image_cycle:
         if k in run_params['kernels']:
             run_params['kernels'][k]['num_weights'] = fit['timesteps_per_stimulus']    
@@ -1115,6 +1120,11 @@ def establish_ephys_timebins(fit, session, run_params):
         kernels_to_limit_per_image_cycle.append('hits')
         kernels_to_limit_per_image_cycle.append('misses')
         kernels_to_limit_per_image_cycle.append('passive_change')
+    if 'hits_image0' in run_params['kernels']:
+        for i in range(0,8):
+            kernels_to_limit_per_image_cycle.append('hits_image{}'.format(i))
+            kernels_to_limit_per_image_cycle.append('misses_image{}'.format(i))
+            kernels_to_limit_per_image_cycle.append('passive_change_image{}'.format(i))
     for k in kernels_to_limit_per_image_cycle:
         if k in run_params['kernels']:
             run_params['kernels'][k]['num_weights'] = fit['timesteps_per_stimulus']    

--- a/visual_behavior_glm_NP/GLM_fit_tools.py
+++ b/visual_behavior_glm_NP/GLM_fit_tools.py
@@ -52,15 +52,15 @@ def load_fit_experiment(ecephys_session_id, run_params):
         kernels_to_limit_per_image_cycle.append('hits')
         kernels_to_limit_per_image_cycle.append('misses')
         kernels_to_limit_per_image_cycle.append('passive_change')
-    if 'hits_image0' in run_params['kernels']:
-        for i in range(0,8):
-            kernels_to_limit_per_image_cycle.append('hits_image{}'.format(i))
-            kernels_to_limit_per_image_cycle.append('misses_image{}'.format(i))
-            kernels_to_limit_per_image_cycle.append('passive_change_image{}'.format(i))
     for k in kernels_to_limit_per_image_cycle:
         if k in run_params['kernels']:
             run_params['kernels'][k]['num_weights'] = fit['timesteps_per_stimulus']    
     kernels_with_image_cycles = ['hits','misses','passive_change','omissions']
+    if 'hits_image0' in run_params['kernels']:
+        for i in range(0,8):
+            kernels_with_image_cycles.append('hits_image{}'.format(i))
+            kernels_with_image_cycles.append('misses_image{}'.format(i))
+            kernels_with_image_cycles.append('passive_change_image{}'.format(i))
     for k in kernels_with_image_cycles:
         if k in run_params['kernels']:
             num_cycles = int(np.floor(run_params['kernels'][k]['length']/.75))
@@ -1120,15 +1120,15 @@ def establish_ephys_timebins(fit, session, run_params):
         kernels_to_limit_per_image_cycle.append('hits')
         kernels_to_limit_per_image_cycle.append('misses')
         kernels_to_limit_per_image_cycle.append('passive_change')
-    if 'hits_image0' in run_params['kernels']:
-        for i in range(0,8):
-            kernels_to_limit_per_image_cycle.append('hits_image{}'.format(i))
-            kernels_to_limit_per_image_cycle.append('misses_image{}'.format(i))
-            kernels_to_limit_per_image_cycle.append('passive_change_image{}'.format(i))
     for k in kernels_to_limit_per_image_cycle:
         if k in run_params['kernels']:
             run_params['kernels'][k]['num_weights'] = fit['timesteps_per_stimulus']    
     kernels_with_image_cycles = ['hits','misses','passive_change','omissions']
+    if 'hits_image0' in run_params['kernels']:
+        for i in range(0,8):
+            kernels_with_image_cycles.append('hits_image{}'.format(i))
+            kernels_with_image_cycles.append('misses_image{}'.format(i))
+            kernels_with_image_cycles.append('passive_change_image{}'.format(i))
     for k in kernels_with_image_cycles:
         if k in run_params['kernels']:
             num_cycles = int(np.floor(run_params['kernels'][k]['length']/.75))

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -26,14 +26,14 @@ def get_versions(vrange=[100,110]):
 def define_kernels():
     kernels = {
         'intercept':    {'event':'intercept',   'type':'continuous',    'length':0,     'offset':0,     'num_weights':None, 'dropout':True, 'text': 'constant value'},
-        'hits':         {'event':'hit',         'type':'discrete',      'length':2.25,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
-        'misses':       {'event':'miss',        'type':'discrete',      'length':2.25,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
-        'passive_change':   {'event':'passive_change','type':'discrete','length':2.25,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
-        'omissions':        {'event':'omissions',   'type':'discrete',  'length':3,     'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
+        'hits':         {'event':'hit',         'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
+        'misses':       {'event':'miss',        'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
+        'passive_change':   {'event':'passive_change','type':'discrete','length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        'omissions':        {'event':'omissions',   'type':'discrete',  'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
         'each-image':   {'event':'each-image',  'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image presentation'},
-        'running':      {'event':'running',     'type':'continuous',    'length':2,     'offset':-1,    'num_weights':None, 'dropout':True, 'text': 'normalized running speed'},
-        'pupil':        {'event':'pupil',       'type':'continuous',    'length':2,     'offset':-1,    'num_weights':None, 'dropout':True, 'text': 'Z-scored pupil diameter'},
-        'licks':        {'event':'licks',       'type':'discrete',      'length':2,     'offset':-1,    'num_weights':None, 'dropout':True, 'text': 'mouse lick'},
+        'running':      {'event':'running',     'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'normalized running speed'},
+        'pupil':        {'event':'pupil',       'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'Z-scored pupil diameter'},
+        'licks':        {'event':'licks',       'type':'discrete',      'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'mouse lick'},
     }
 
     return kernels

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -18,6 +18,9 @@ OUTPUT_DIR_BASE ='/allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys
     104: shorter behavioral kernels
     105: image specific change kernels
     106: omission/hit/miss -> 1.5s
+    107: 106 had a bug, repeating, but with 2s behavior
+    108: 107 comparison with non-specific change kernels
+    109: 108 comparison with 1s behavior
 
 '''
 
@@ -35,12 +38,12 @@ def get_versions(vrange=[100,110]):
 def define_kernels():
     kernels = {
         'intercept':    {'event':'intercept',   'type':'continuous',    'length':0,     'offset':0,     'num_weights':None, 'dropout':True, 'text': 'constant value'},
-        #'hits':         {'event':'hit',         'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
-        #'misses':       {'event':'miss',        'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
-        #'passive_change':   {'event':'passive_change','type':'discrete','length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
-        'each-image_change':{'event':'image_change','type':'discrete',  'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        'hits':         {'event':'hit',         'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
+        'misses':       {'event':'miss',        'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
+        'passive_change':   {'event':'passive_change','type':'discrete','length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        #'each-image_change':{'event':'image_change','type':'discrete',  'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
         'omissions':        {'event':'omissions',   'type':'discrete',  'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
-        'each-image':   {'event':'each-image',  'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image presentation'},
+        'each-image':   {'event':'each-image',  'type':'discrete',      'length':0.75,  'offset':0,   'num_weights':None, 'dropout':True, 'text': 'image presentation'},
         'running':      {'event':'running',     'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'normalized running speed'},
         'pupil':        {'event':'pupil',       'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'Z-scored pupil diameter'},
         'licks':        {'event':'licks',       'type':'discrete',      'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'mouse lick'},

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -232,7 +232,7 @@ def make_run_json(VERSION,label='',username=None, src_path=None, TESTING=False,
     # Make sub-directories for figure kernels
     for k in kernels:
         os.mkdir(fig_kernels_dir+'/'+k)
-    extra_kernels=['all-images','preferred_image','shared_image','non_shared_image']
+    extra_kernels=['all-images','preferred_image','shared_images','non_shared_images']
     for k in extra_kernels:
         os.mkdir(fig_kernels_dir+'/'+k)
 

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -11,6 +11,13 @@ from allensdk.brain_observatory.behavior.behavior_project_cache import \
     VisualBehaviorNeuropixelsProjectCache
 
 OUTPUT_DIR_BASE ='/allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys/'
+'''
+    102, 25ms, old mongo
+    102_m, 25ms, new mongo
+    103: shorter hit/miss/omission kernels
+    104: shorter behavioral kernels
+    105: image specific change kernels
+'''
 
 def get_versions(vrange=[100,110]):
     versions = os.listdir(OUTPUT_DIR_BASE)

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -17,6 +17,8 @@ OUTPUT_DIR_BASE ='/allen/programs/braintv/workgroups/nc-ophys/alex.piet/NP/ephys
     103: shorter hit/miss/omission kernels
     104: shorter behavioral kernels
     105: image specific change kernels
+    106: omission/hit/miss -> 1.5s
+
 '''
 
 def get_versions(vrange=[100,110]):
@@ -33,11 +35,11 @@ def get_versions(vrange=[100,110]):
 def define_kernels():
     kernels = {
         'intercept':    {'event':'intercept',   'type':'continuous',    'length':0,     'offset':0,     'num_weights':None, 'dropout':True, 'text': 'constant value'},
-        #'hits':         {'event':'hit',         'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
-        #'misses':       {'event':'miss',        'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
-        #'passive_change':   {'event':'passive_change','type':'discrete','length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
-        'each-image_change':{'event':'image_change','type':'discrete',  'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
-        'omissions':        {'event':'omissions',   'type':'discrete',  'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
+        #'hits':         {'event':'hit',         'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
+        #'misses':       {'event':'miss',        'type':'discrete',      'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
+        #'passive_change':   {'event':'passive_change','type':'discrete','length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        'each-image_change':{'event':'image_change','type':'discrete',  'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        'omissions':        {'event':'omissions',   'type':'discrete',  'length':1.5,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
         'each-image':   {'event':'each-image',  'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image presentation'},
         'running':      {'event':'running',     'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'normalized running speed'},
         'pupil':        {'event':'pupil',       'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'Z-scored pupil diameter'},

--- a/visual_behavior_glm_NP/GLM_params.py
+++ b/visual_behavior_glm_NP/GLM_params.py
@@ -26,9 +26,10 @@ def get_versions(vrange=[100,110]):
 def define_kernels():
     kernels = {
         'intercept':    {'event':'intercept',   'type':'continuous',    'length':0,     'offset':0,     'num_weights':None, 'dropout':True, 'text': 'constant value'},
-        'hits':         {'event':'hit',         'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
-        'misses':       {'event':'miss',        'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
-        'passive_change':   {'event':'passive_change','type':'discrete','length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        #'hits':         {'event':'hit',         'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'lick to image change'},
+        #'misses':       {'event':'miss',        'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'no lick to image change'},
+        #'passive_change':   {'event':'passive_change','type':'discrete','length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
+        'each-image_change':{'event':'image_change','type':'discrete',  'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'passive session image change'},
         'omissions':        {'event':'omissions',   'type':'discrete',  'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image was omitted'},
         'each-image':   {'event':'each-image',  'type':'discrete',      'length':0.75,  'offset':0,     'num_weights':None, 'dropout':True, 'text': 'image presentation'},
         'running':      {'event':'running',     'type':'continuous',    'length':1,     'offset':-0.5,  'num_weights':None, 'dropout':True, 'text': 'normalized running speed'},
@@ -283,8 +284,12 @@ def process_kernels(kernels):
     if 'each-image_change' in kernels:
         specs = kernels.pop('each-image_change')
         for index, val in enumerate(range(0,8)):
-            kernels['image_change'+str(val)] = copy(specs)
-            kernels['image_change'+str(val)]['event'] = 'image_change'+str(val)
+            kernels['hits_image'+str(val)] = copy(specs)
+            kernels['hits_image'+str(val)]['event'] = 'hit_image'+str(val)
+            kernels['misses_image'+str(val)] = copy(specs)
+            kernels['misses_image'+str(val)]['event'] = 'miss_image'+str(val)
+            kernels['passive_change_image'+str(val)] = copy(specs)
+            kernels['passive_change_image'+str(val)]['event'] = 'passive_change_image'+str(val)
     if 'beh_model' in kernels:
         specs = kernels.pop('beh_model')
         weight_names = ['bias','task0','omissions1','timing1D']
@@ -313,8 +318,10 @@ def define_dropouts(kernels,run_params):
 
         # Define the nested_models
         dropout_definitions={
-            'all-images':           ['image0','image1','image2','image3','image4','image5','image6','image7'],
-            'task':                 ['hits','misses','passive_change','post-hits','post-misses','post-passive_change'],
+            'all-images':           ['image0','image1','image2','image3',
+                                    'image4','image5','image6','image7'],
+            'task':                 ['hits','misses','passive_change','post-hits',
+                                    'post-misses','post-passive_change'],
             'behavioral':           ['running','pupil','licks'],
             }
         
@@ -324,10 +331,25 @@ def define_dropouts(kernels,run_params):
             dropout_definitions['all-hits']=            ['hits','post-hits']
             dropout_definitions['all-misses']=          ['misses','post-misses']
             dropout_definitions['all-passive_change']=  ['passive_change','post-passive_change']
-            dropout_definitions['post-task']=           ['post-hits','post-misses','post-passive_change']
+            dropout_definitions['post-task']=           ['post-hits','post-misses',
+                                                        'post-passive_change']
             dropout_definitions['task']=                ['hits','misses','passive_change']
-            dropout_definitions['all-task']=            ['hits','misses','passive_change','post-hits','post-misses','post-passive_change']
-        
+            dropout_definitions['all-task']=            ['hits','misses','passive_change',
+                                                    'post-hits','post-misses','post-passive_change']
+        if 'hits_image0' in kernels:
+            dropout_definitions['hits'] = ['hits_image0','hits_image1','hits_image2',
+                'hits_image3','hits_image4','hits_image5','hits_image6','hits_image7']
+            dropout_definitions['misses'] = ['misses_image0','misses_image1','misses_image2',
+                'misses_image3','misses_image4','misses_image5','misses_image6','misses_image7']
+            dropout_definitions['passive_change'] = ['passive_change_image0',
+                'passive_change_image1','passive_change_image2','passive_change_image3',
+                'passive_change_image4','passive_change_image5','passive_change_image6',
+                'passive_change_image7']
+            dropout_definitions['task'] = []
+            dropout_definitions['task'].extend(dropout_definitions['hits'])
+            dropout_definitions['task'].extend(dropout_definitions['misses'])
+            dropout_definitions['task'].extend(dropout_definitions['passive_change'])
+ 
         # For each nested model, move the appropriate kernels to the dropped_kernel list
         for dropout_name in dropout_definitions:
             dropouts = set_up_dropouts(dropouts, kernels, dropout_name, dropout_definitions[dropout_name])

--- a/visual_behavior_glm_NP/GLM_visualization_tools.py
+++ b/visual_behavior_glm_NP/GLM_visualization_tools.py
@@ -2261,6 +2261,8 @@ def get_time_vec(kernel, run_params):
     time_vec = np.round(time_vec,3) 
     if ('image' in kernel) & ('_image' not in kernel):
         time_vec = time_vec[:-1]
+    if ('shared_image' in kernel):
+        time_vec = time_vec[:-1]
     if ('omissions' == kernel) & ('post-omissions' in run_params['kernels']):
         time_vec = time_vec[:-1]
     if ('hits' == kernel) & ('post-hits' in run_params['kernels']):

--- a/visual_behavior_glm_NP/GLM_visualization_tools.py
+++ b/visual_behavior_glm_NP/GLM_visualization_tools.py
@@ -2037,7 +2037,7 @@ def plot_kernel_comparison(weights_df, run_params, kernel, save_results=True, dr
     filename = os.path.join(run_params['fig_kernels_dir'],kernel,kernel+'_comparison_by_experience'+filter_string+'.png')
 
     # Set up time vectors.
-    if kernel in ['preferred_image', 'all-images','shared_image','non_shared_image','shared_image_corrected','non_shared_image_corrected']:
+    if kernel in ['preferred_image', 'all-images','shared_images','non_shared_images','shared_image_corrected','non_shared_image_corrected']:
         run_params['kernels'][kernel] = run_params['kernels']['image0'].copy()
     if kernel == 'all-omissions':
         run_params['kernels'][kernel] = run_params['kernels']['omissions'].copy()
@@ -2334,7 +2334,7 @@ def kernel_evaluation(weights_df, run_params, kernel, save_results=False, drop_t
         threshold = 0.005
 
     # Set up time vectors.
-    if kernel in ['preferred_image', 'all-images','shared_image','non_shared_image']:
+    if kernel in ['preferred_image', 'all-images','shared_images','non_shared_images']:
         run_params['kernels'][kernel] = run_params['kernels']['image0'].copy()
     if kernel == 'all-omissions':
         run_params['kernels'][kernel] = run_params['kernels']['omissions'].copy()
@@ -4420,7 +4420,7 @@ def plot_dropout_individual_population(results, run_params,ax=None,palette=None,
 def plot_dropout_summary_by_area(results, run_params,dropout='all-images',
     ax=None,palette=None,add_median=True,include_zero_cells=True,add_title=False,
     dropout_cleaning_threshold=None, exclusion_threshold=None,
-    savefig=False,sort_order='coding',min_cells=100,merged=True): 
+    savefig=False,sort_order='coding',min_cells=100,merged=False): 
     '''
         Makes a bar plot that shows the population dropout summary by area 
         palette , color palette to use. If None, uses gvt.project_colors()

--- a/visual_behavior_glm_NP/GLM_visualization_tools.py
+++ b/visual_behavior_glm_NP/GLM_visualization_tools.py
@@ -2259,7 +2259,7 @@ def get_time_vec(kernel, run_params):
         run_params['kernels'][kernel]['offset'] + run_params['kernels'][kernel]['length'],
         run_params['spike_bin_width'])
     time_vec = np.round(time_vec,3) 
-    if 'image' in kernel:
+    if ('image' in kernel) & ('_image' not in kernel):
         time_vec = time_vec[:-1]
     if ('omissions' == kernel) & ('post-omissions' in run_params['kernels']):
         time_vec = time_vec[:-1]
@@ -2269,8 +2269,10 @@ def get_time_vec(kernel, run_params):
         time_vec = time_vec[:-1]
     if ('passive_change' == kernel) & ('post-passive_change' in run_params['kernels']):
         time_vec = time_vec[:-1]
-    
-    if kernel in ['hits','misses','omissions','passive_change']:   
+
+    if (kernel in ['hits','misses','omissions','passive_change']) or\
+        ('hits_image' in kernel) or ('misses_image' in kernel) or \
+        ('passive_change_image' in kernel):   
         timesteps_per_stimulus = int(.75/run_params['spike_bin_width'] - 1)
         i = 1
         while i*timesteps_per_stimulus < len(time_vec):

--- a/visual_behavior_glm_NP/GLM_visualization_tools.py
+++ b/visual_behavior_glm_NP/GLM_visualization_tools.py
@@ -2562,7 +2562,6 @@ def kernel_evaluation(weights_df, run_params, kernel, save_results=False, drop_t
         ncells={
             'exc':np.shape(slc)[1],
             }
-        print('here')
         ####zlims = plot_kernel_heatmap(weights_sorted,time_vec, kernel, run_params,ncells,session_filter=session_filter,savefig=save_results)
         #zlims_test = plot_kernel_heatmap_with_dropout(vip_table, sst_table, slc_table,time_vec, kernel, run_params,ncells,session_filter=session_filter)
     else:
@@ -2612,7 +2611,6 @@ def kernel_evaluation(weights_df, run_params, kernel, save_results=False, drop_t
         ncells_f={
             'exc':np.shape(slc_f)[1],
             }
-        print('here')
         #zlims = plot_kernel_heatmap(weights_sorted_f,time_vec, kernel, run_params,ncells_f,extra='full_model',zlims=zlims,session_filter=session_filter,savefig=save_results) 
     else:
         # For each dropout, plot score
@@ -2659,7 +2657,6 @@ def kernel_evaluation(weights_df, run_params, kernel, save_results=False, drop_t
         ncells_df={
             'exc':np.shape(slc_df)[1],
             }
-        print('here')
         #zlims = plot_kernel_heatmap(weights_sorted_df,time_vec, kernel, run_params,ncells_df,extra='dropout',zlims=None,session_filter=session_filter,savefig=save_results)
         #zlims_test = plot_kernel_heatmap_with_dropout(vip_table_df, sst_table_df, slc_table_df,time_vec, kernel, run_params,ncells_df,session_filter=session_filter,zlims=zlims,extra='dropout',savefig=save_results)
 


### PR DESCRIPTION
- [x] version comparison (VE, image, behavioral, omissions, task)
  - 102 (benchmark): 6.5%, 30, 32, 3.3, 6.7
  - 103 (.75ms task): 6.4%, 32, 34,16, 9
  - 104 (1s behavior): 6.3%, 33, 33, 17, 11
  - X 105: (per-image): 6.3%, 34, 35, 17, 5
  -  X 106: (per-image): 6.3%, 34, 35, 17, 5
  - 107 (per-image 1.5s, 2s B): 6.4%, 32, 35, 6.0, 3.4
  - 108 (107 comparison):6.5%, 31, 33, 6.1, 7.9
  - 109 (108 comparison, 1s B): 6.4%, 32, 32, 6.2, 9.6
- Addressing #7 
   - running looks similar with 1 vs 2secs
   - pupil looks bad with 1 second, interesting features farther out
   - licks looks cleaner with 1 second, fitting more noise farther out
   - I think I want them all to be the same length
   - I think 2sec is better than 1 sec
- [x] addressing #1 
   - might be problem with small number of hit/miss for each image. could get funky with CV
   - per-image change kernels lead to dramatic reduction in task coding -> I suspect this means we don't have enough data
- [x] document running, pupil, licks kernels between all versions
- [x] The only remaining question is whether the issue with NaNs is tanking the coding scores?
- [x] make final recommendations and fit stable version
- [x] clean up old version on filesystem and mongo